### PR TITLE
Add an option to run as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bumped FlowKit to 1.33.1
 - Busybox docker now comes from `docker.from_env()` to support both d-in-d and port binding
 
+## Added
+
+- Added a new `start_as_root` option to `PapermillOperator` which starts the lab container with uid 0, and relies on the container to switch to the correct user. This resolves issues with permissions on the in container home directory in some cases when running as a specific user.
+
 ## [1.3.3]
 
 ### Changed

--- a/tests/test_flowpyter_operator.py
+++ b/tests/test_flowpyter_operator.py
@@ -529,3 +529,21 @@ def test_make_dir_with_docker(monkeypatch, tmp_path, base_dag):
     foo.notebook_gid = os.getgid()
     foo.create_path_on_host(tmp_path, "new_file")
     assert (tmp_path / "new_file").exists()
+
+
+def test_run_as_root():
+    """When starting as root, we should get uid/gid 0 and push the provided
+    notebook user and group to environment variables."""
+    from flowpytertask import PapermillOperator
+
+    op = PapermillOperator(
+        notebook_name="_.ipynb",
+        host_notebook_dir="_",
+        host_notebook_out_dir="_",
+        host_dagrun_data_dir="_",
+        task_id="_",
+        start_as_root=True,
+    )
+    assert op.user == "0:0"
+    assert op.environment["NB_UID"] == op.notebook_uid
+    assert op.environment["NB_GID"] == op.notebook_gid


### PR DESCRIPTION
Adds an option to start containers as root instead and delegate running as the supplied user to the notebook container.